### PR TITLE
feat(components): ssh 节点支持公钥认证，私钥支持内容/文件路径/passphrase 解密

### DIFF
--- a/components/external/ssh_node.go
+++ b/components/external/ssh_node.go
@@ -26,10 +26,26 @@ package external
 //"cmd": "sh count.sh test.txt hello"
 //}
 //}
+//
+// 公钥认证示例（密码与私钥至少配置其一）：
+// Public key auth example (password and private key are alternatives):
+//
+//	{
+//	  "type": "ssh",
+//	  "config": {
+//	    "host": "192.168.1.1",
+//	    "port": 22,
+//	    "username": "root",
+//	    "privateKeyPath": "/root/.ssh/id_rsa",
+//	    "privateKeyPassphrase": "key-passphrase",
+//	    "cmd": "ls /tmp"
+//	  }
+//	}
 
 import (
 	"errors"
 	"fmt"
+	"os"
 	"sync/atomic"
 
 	"github.com/rulego/rulego/api/types"
@@ -40,9 +56,10 @@ import (
 )
 
 var (
-	SshConfigEmptyErr   = errors.New("ssh config can not empty")
-	SshClientNotInitErr = errors.New("ssh client not initialized")
-	SshCmdEmptyErr      = errors.New("cmd can not empty")
+	SshConfigEmptyErr           = errors.New("ssh config can not empty")
+	SshClientNotInitErr         = errors.New("ssh client not initialized")
+	SshCmdEmptyErr              = errors.New("cmd can not empty")
+	SshConfigPassphraseNoKeyErr = errors.New("ssh privateKeyPassphrase configured but no private key")
 )
 
 func init() {
@@ -60,6 +77,15 @@ type SshConfiguration struct {
 	Username string `json:"username" label:"Username" desc:"SSH login username" required:"true"`
 	// Password is the SSH login password.
 	Password string `json:"password" label:"Password" desc:"SSH login password" required:"true"`
+	// PrivateKey is the SSH private key PEM content (e.g. -----BEGIN OPENSSH PRIVATE KEY-----).
+	// Mutually exclusive with PrivateKeyPath; PrivateKey takes precedence when both are set.
+	PrivateKey string `json:"privateKey,omitempty" label:"Private Key" desc:"SSH private key PEM content, e.g. -----BEGIN OPENSSH PRIVATE KEY-----"`
+	// PrivateKeyPath is the path to the SSH private key file (e.g. /root/.ssh/id_rsa).
+	// Mutually exclusive with PrivateKey; PrivateKey takes precedence when both are set.
+	PrivateKeyPath string `json:"privateKeyPath,omitempty" label:"Private Key File" desc:"SSH private key file path, e.g. /root/.ssh/id_rsa"`
+	// PrivateKeyPassphrase is the passphrase of the encrypted private key.
+	// Required only when the configured private key is encrypted.
+	PrivateKeyPassphrase string `json:"privateKeyPassphrase,omitempty" label:"Private Key Passphrase" desc:"Passphrase of the encrypted private key, required only when the private key is encrypted"`
 	// Cmd is the shell command. Supports ${metadata.key} and ${msg.key} substitution.
 	Cmd string `json:"cmd" label:"Command" desc:"Shell command to execute. Supports ${metadata.key} and ${msg.key} substitution" required:"true"`
 }
@@ -85,7 +111,9 @@ type SshConfiguration struct {
 //		"host": "192.168.1.100",        // SSH服务器地址 - SSH server address
 //		"port": 22,                     // SSH端口 - SSH port
 //		"username": "admin",            // 用户名 - Username
-//		"password": "secret123",        // 密码 - Password
+//		"password": "secret123",        // 密码 - Password (密码与私钥至少配置其一 - password and private key are alternatives)
+//		"privateKeyPath": "/root/.ssh/id_rsa",            // 私钥文件路径 - Private key file path
+//		"privateKeyPassphrase": "key-passphrase",         // 私钥口令（私钥加密时必填）- Passphrase of encrypted private key
 //		"cmd": "ls -la /tmp/${metadata.path}"  // 支持变量替换的命令 - Command with variables
 //	}
 //
@@ -134,6 +162,9 @@ type SshNode struct {
 	// connHealthy 缓存连接健康标记，避免每条消息都调 SetStatus
 	// connHealthy caches connection health to avoid SetStatus on every message
 	connHealthy int32
+	// signer 私钥签名器，Init 时解析并缓存，用于公钥认证；未配置私钥时为 nil
+	// signer is parsed and cached at Init time for public key auth; nil when no private key is configured
+	signer ssh.Signer
 }
 
 // Type 方法用来返回组件的类型
@@ -157,11 +188,24 @@ func (x *SshNode) Init(ruleConfig types.Config, configuration types.Configuratio
 	if err != nil {
 		return err
 	}
-	if x.Config.Host == "" || x.Config.Port == 0 || x.Config.Username == "" || x.Config.Password == "" {
+	if x.Config.Host == "" || x.Config.Port == 0 || x.Config.Username == "" {
 		return SshConfigEmptyErr
+	}
+	// 密码与私钥至少配置其一 - require password or private key
+	if x.Config.Password == "" && x.Config.PrivateKey == "" && x.Config.PrivateKeyPath == "" {
+		return SshConfigEmptyErr
+	}
+	// 配置了私钥口令但没有私钥 - passphrase without private key
+	if x.Config.PrivateKeyPassphrase != "" && x.Config.PrivateKey == "" && x.Config.PrivateKeyPath == "" {
+		return SshConfigPassphraseNoKeyErr
 	}
 	if x.Config.Cmd == "" {
 		return SshCmdEmptyErr
+	}
+	// 解析并缓存私钥签名器，提前暴露密钥格式/口令错误 - parse the private key early (fail-fast)
+	x.signer, err = x.parseSigner()
+	if err != nil {
+		return err
 	}
 	addr := fmt.Sprintf("%s:%d", x.Config.Host, x.Config.Port)
 	err = x.SharedNode.InitWithClose(ruleConfig, x.Type(), addr, ruleConfig.NodeClientInitNow, func() (*ssh.Client, error) {
@@ -248,17 +292,64 @@ func (x *SshNode) Destroy() {
 	_ = x.SharedNode.Close()
 }
 
+// clientConfig 构建 SSH 客户端配置。
+// clientConfig builds the SSH client configuration.
+func (x *SshNode) clientConfig() *ssh.ClientConfig {
+	// 密码与公钥认证可共存，由 SSH 服务器协商选择 - password and public key auth can coexist
+	authMethods := make([]ssh.AuthMethod, 0, 2)
+	if x.Config.Password != "" {
+		authMethods = append(authMethods, ssh.Password(x.Config.Password))
+	}
+	if x.signer != nil {
+		authMethods = append(authMethods, ssh.PublicKeys(x.signer))
+	}
+	return &ssh.ClientConfig{
+		User:            x.Config.Username,
+		Auth:            authMethods,
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+}
+
 // initClient 拨号建立 SSH 连接
 // initClient dials the SSH server.
 func (x *SshNode) initClient() (*ssh.Client, error) {
-	config := &ssh.ClientConfig{
-		User: x.Config.Username,
-		Auth: []ssh.AuthMethod{
-			ssh.Password(x.Config.Password),
-		},
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	return ssh.Dial("tcp", fmt.Sprintf("%s:%d", x.Config.Host, x.Config.Port), x.clientConfig())
+}
+
+// parseSigner 解析私钥并返回签名器；未配置私钥时返回 nil。
+// parseSigner parses the configured private key into a signer; returns nil when no private key is configured.
+// 私钥内容 (PrivateKey) 优先于文件路径 (PrivateKeyPath)。
+// PrivateKey content takes precedence over PrivateKeyPath.
+func (x *SshNode) parseSigner() (ssh.Signer, error) {
+	if x.Config.PrivateKey == "" && x.Config.PrivateKeyPath == "" {
+		return nil, nil
 	}
-	return ssh.Dial("tcp", fmt.Sprintf("%s:%d", x.Config.Host, x.Config.Port), config)
+	var pemBytes []byte
+	var err error
+	if x.Config.PrivateKey != "" {
+		pemBytes = []byte(x.Config.PrivateKey)
+	} else {
+		pemBytes, err = os.ReadFile(x.Config.PrivateKeyPath)
+		if err != nil {
+			return nil, fmt.Errorf("ssh: read private key file %s: %w", x.Config.PrivateKeyPath, err)
+		}
+	}
+	if x.Config.PrivateKeyPassphrase != "" {
+		signer, err := ssh.ParsePrivateKeyWithPassphrase(pemBytes, []byte(x.Config.PrivateKeyPassphrase))
+		if err != nil {
+			return nil, fmt.Errorf("ssh: parse encrypted private key: %w", err)
+		}
+		return signer, nil
+	}
+	signer, err := ssh.ParsePrivateKey(pemBytes)
+	if err != nil {
+		var missing *ssh.PassphraseMissingError
+		if errors.As(err, &missing) {
+			return nil, errors.New("ssh: private key is encrypted, please configure privateKeyPassphrase")
+		}
+		return nil, fmt.Errorf("ssh: parse private key: %w", err)
+	}
+	return signer, nil
 }
 
 // Desc returns the component description

--- a/components/external/ssh_node.go
+++ b/components/external/ssh_node.go
@@ -27,8 +27,8 @@ package external
 //}
 //}
 //
-// 公钥认证示例（密码与私钥至少配置其一）：
-// Public key auth example (password and private key are alternatives):
+// 公钥认证示例（密码与私钥互斥，二选一；certKeyFile 支持 PEM 内容或文件路径，自动识别）：
+// Public key auth example (password and private key are mutually exclusive; certKeyFile accepts PEM content or a file path, auto-detected):
 //
 //	{
 //	  "type": "ssh",
@@ -36,8 +36,8 @@ package external
 //	    "host": "192.168.1.1",
 //	    "port": 22,
 //	    "username": "root",
-//	    "privateKeyPath": "/root/.ssh/id_rsa",
-//	    "privateKeyPassphrase": "key-passphrase",
+//	    "certKeyFile": "/root/.ssh/id_rsa",
+//	    "password": "key-passphrase",
 //	    "cmd": "ls /tmp"
 //	  }
 //	}
@@ -46,6 +46,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"sync/atomic"
 
 	"github.com/rulego/rulego/api/types"
@@ -56,10 +57,10 @@ import (
 )
 
 var (
-	SshConfigEmptyErr           = errors.New("ssh config can not empty")
-	SshClientNotInitErr         = errors.New("ssh client not initialized")
-	SshCmdEmptyErr              = errors.New("cmd can not empty")
-	SshConfigPassphraseNoKeyErr = errors.New("ssh privateKeyPassphrase configured but no private key")
+	SshConfigEmptyErr                = errors.New("ssh config can not empty")
+	SshClientNotInitErr              = errors.New("ssh client not initialized")
+	SshCmdEmptyErr                   = errors.New("cmd can not empty")
+	SshConfigPasswordKeyExclusiveErr = errors.New("ssh password and certKeyFile are mutually exclusive")
 )
 
 func init() {
@@ -76,16 +77,13 @@ type SshConfiguration struct {
 	// Username is the SSH login username.
 	Username string `json:"username" label:"Username" desc:"SSH login username" required:"true"`
 	// Password is the SSH login password.
-	Password string `json:"password" label:"Password" desc:"SSH login password" required:"true"`
-	// PrivateKey is the SSH private key PEM content (e.g. -----BEGIN OPENSSH PRIVATE KEY-----).
-	// Mutually exclusive with PrivateKeyPath; PrivateKey takes precedence when both are set.
-	PrivateKey string `json:"privateKey,omitempty" label:"Private Key" desc:"SSH private key PEM content, e.g. -----BEGIN OPENSSH PRIVATE KEY-----"`
-	// PrivateKeyPath is the path to the SSH private key file (e.g. /root/.ssh/id_rsa).
-	// Mutually exclusive with PrivateKey; PrivateKey takes precedence when both are set.
-	PrivateKeyPath string `json:"privateKeyPath,omitempty" label:"Private Key File" desc:"SSH private key file path, e.g. /root/.ssh/id_rsa"`
-	// PrivateKeyPassphrase is the passphrase of the encrypted private key.
-	// Required only when the configured private key is encrypted.
-	PrivateKeyPassphrase string `json:"privateKeyPassphrase,omitempty" label:"Private Key Passphrase" desc:"Passphrase of the encrypted private key, required only when the private key is encrypted"`
+	// When CertKeyFile is set (public key auth), it is used as the passphrase of the encrypted private key.
+	// Password and CertKeyFile are mutually exclusive.
+	Password string `json:"password" label:"Password" desc:"SSH login password; when certKeyFile is set, used as the passphrase of the encrypted private key"`
+	// CertKeyFile is the SSH private key: PEM content (e.g. -----BEGIN OPENSSH PRIVATE KEY-----) or a file path (e.g. /root/.ssh/id_rsa).
+	// Auto-detected: content starting with -----BEGIN is treated as PEM content, otherwise as a file path.
+	// Mutually exclusive with Password; when set, Password acts as the private key passphrase.
+	CertKeyFile string `json:"certKeyFile,omitempty" label:"Cert Key File" desc:"SSH private key PEM content or file path, auto-detected; mutually exclusive with password"`
 	// Cmd is the shell command. Supports ${metadata.key} and ${msg.key} substitution.
 	Cmd string `json:"cmd" label:"Command" desc:"Shell command to execute. Supports ${metadata.key} and ${msg.key} substitution" required:"true"`
 }
@@ -112,8 +110,8 @@ type SshConfiguration struct {
 //		"port": 22,                     // SSH端口 - SSH port
 //		"username": "admin",            // 用户名 - Username
 //		"password": "secret123",        // 密码 - Password (密码与私钥至少配置其一 - password and private key are alternatives)
-//		"privateKeyPath": "/root/.ssh/id_rsa",            // 私钥文件路径 - Private key file path
-//		"privateKeyPassphrase": "key-passphrase",         // 私钥口令（私钥加密时必填）- Passphrase of encrypted private key
+//		"certKeyFile": "/root/.ssh/id_rsa",               // 私钥 PEM 内容或文件路径，自动识别 - Private key PEM content or file path, auto-detected
+//		"password": "key-passphrase",                     // 私钥口令（私钥加密时必填）- Passphrase of encrypted private key (password is reused)
 //		"cmd": "ls -la /tmp/${metadata.path}"  // 支持变量替换的命令 - Command with variables
 //	}
 //
@@ -192,12 +190,12 @@ func (x *SshNode) Init(ruleConfig types.Config, configuration types.Configuratio
 		return SshConfigEmptyErr
 	}
 	// 密码与私钥至少配置其一 - require password or private key
-	if x.Config.Password == "" && x.Config.PrivateKey == "" && x.Config.PrivateKeyPath == "" {
+	if x.Config.Password == "" && x.Config.CertKeyFile == "" {
 		return SshConfigEmptyErr
 	}
-	// 配置了私钥口令但没有私钥 - passphrase without private key
-	if x.Config.PrivateKeyPassphrase != "" && x.Config.PrivateKey == "" && x.Config.PrivateKeyPath == "" {
-		return SshConfigPassphraseNoKeyErr
+	// 密码认证与私钥认证互斥 - password auth and public key auth are mutually exclusive
+	if x.Config.Password != "" && x.Config.CertKeyFile != "" {
+		return SshConfigPasswordKeyExclusiveErr
 	}
 	if x.Config.Cmd == "" {
 		return SshCmdEmptyErr
@@ -295,13 +293,13 @@ func (x *SshNode) Destroy() {
 // clientConfig 构建 SSH 客户端配置。
 // clientConfig builds the SSH client configuration.
 func (x *SshNode) clientConfig() *ssh.ClientConfig {
-	// 密码与公钥认证可共存，由 SSH 服务器协商选择 - password and public key auth can coexist
-	authMethods := make([]ssh.AuthMethod, 0, 2)
-	if x.Config.Password != "" {
-		authMethods = append(authMethods, ssh.Password(x.Config.Password))
-	}
+	// 密码认证与公钥认证互斥：配置私钥时仅用公钥认证（Password 作为私钥口令），否则仅用密码认证
+	// password and public key auth are mutually exclusive: public key only when a private key is set (Password acts as passphrase), otherwise password only
+	var authMethods []ssh.AuthMethod
 	if x.signer != nil {
 		authMethods = append(authMethods, ssh.PublicKeys(x.signer))
+	} else if x.Config.Password != "" {
+		authMethods = append(authMethods, ssh.Password(x.Config.Password))
 	}
 	return &ssh.ClientConfig{
 		User:            x.Config.Username,
@@ -318,38 +316,49 @@ func (x *SshNode) initClient() (*ssh.Client, error) {
 
 // parseSigner 解析私钥并返回签名器；未配置私钥时返回 nil。
 // parseSigner parses the configured private key into a signer; returns nil when no private key is configured.
-// 私钥内容 (PrivateKey) 优先于文件路径 (PrivateKeyPath)。
-// PrivateKey content takes precedence over PrivateKeyPath.
+// CertKeyFile 支持 PEM 内容或文件路径（自动识别）；私钥加密时 Password 作为口令，未加密时忽略 Password。
+// CertKeyFile accepts PEM content or a file path (auto-detected); Password is used as the passphrase only when the private key is encrypted.
 func (x *SshNode) parseSigner() (ssh.Signer, error) {
-	if x.Config.PrivateKey == "" && x.Config.PrivateKeyPath == "" {
+	if x.Config.CertKeyFile == "" {
 		return nil, nil
 	}
-	var pemBytes []byte
-	var err error
-	if x.Config.PrivateKey != "" {
-		pemBytes = []byte(x.Config.PrivateKey)
-	} else {
-		pemBytes, err = os.ReadFile(x.Config.PrivateKeyPath)
-		if err != nil {
-			return nil, fmt.Errorf("ssh: read private key file %s: %w", x.Config.PrivateKeyPath, err)
-		}
+	pemBytes, err := x.loadKeyBytes()
+	if err != nil {
+		return nil, err
 	}
-	if x.Config.PrivateKeyPassphrase != "" {
-		signer, err := ssh.ParsePrivateKeyWithPassphrase(pemBytes, []byte(x.Config.PrivateKeyPassphrase))
-		if err != nil {
-			return nil, fmt.Errorf("ssh: parse encrypted private key: %w", err)
-		}
-		return signer, nil
-	}
+	// 先按无口令私钥解析；若是加密私钥（PassphraseMissingError），再按需使用 Password 作为口令解析
+	// try parsing as a plain private key first; if the key is encrypted (PassphraseMissingError), parse with Password as the passphrase
 	signer, err := ssh.ParsePrivateKey(pemBytes)
 	if err != nil {
 		var missing *ssh.PassphraseMissingError
 		if errors.As(err, &missing) {
-			return nil, errors.New("ssh: private key is encrypted, please configure privateKeyPassphrase")
+			if x.Config.Password == "" {
+				return nil, errors.New("ssh: private key is encrypted, please configure password (used as passphrase)")
+			}
+			signer, err = ssh.ParsePrivateKeyWithPassphrase(pemBytes, []byte(x.Config.Password))
+			if err != nil {
+				return nil, fmt.Errorf("ssh: parse encrypted private key: %w", err)
+			}
+			return signer, nil
 		}
 		return nil, fmt.Errorf("ssh: parse private key: %w", err)
 	}
 	return signer, nil
+}
+
+// loadKeyBytes 自动识别 CertKeyFile 是 PEM 内容还是文件路径并返回私钥字节。
+// loadKeyBytes auto-detects whether CertKeyFile holds PEM content or a file path and returns the key bytes.
+// 以 -----BEGIN 开头视为 PEM 内容，否则按文件路径读取。
+// Content starting with -----BEGIN is treated as PEM content; otherwise CertKeyFile is read as a file path.
+func (x *SshNode) loadKeyBytes() ([]byte, error) {
+	if strings.HasPrefix(strings.TrimSpace(x.Config.CertKeyFile), "-----BEGIN") {
+		return []byte(x.Config.CertKeyFile), nil
+	}
+	data, err := os.ReadFile(x.Config.CertKeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("ssh: read private key file %s: %w", x.Config.CertKeyFile, err)
+	}
+	return data, nil
 }
 
 // Desc returns the component description

--- a/components/external/ssh_node_key_test.go
+++ b/components/external/ssh_node_key_test.go
@@ -66,14 +66,14 @@ func TestSshNodeParseSigner(t *testing.T) {
 		errContains string
 	}{
 		{"no private key", SshConfiguration{}, true, false, ""},
-		{"plain PEM content", SshConfiguration{PrivateKey: plainPEM}, false, false, ""},
-		{"plain PEM file", SshConfiguration{PrivateKeyPath: keyPath}, false, false, ""},
-		{"privateKey content takes precedence over path", SshConfiguration{PrivateKey: plainPEM, PrivateKeyPath: filepath.Join(dir, "missing")}, false, false, ""},
-		{"encrypted with correct passphrase", SshConfiguration{PrivateKey: encryptedPEM, PrivateKeyPassphrase: passphrase}, false, false, ""},
-		{"encrypted with wrong passphrase", SshConfiguration{PrivateKey: encryptedPEM, PrivateKeyPassphrase: "wrong-passphrase"}, false, true, ""},
-		{"encrypted without passphrase", SshConfiguration{PrivateKey: encryptedPEM}, false, true, "privateKeyPassphrase"},
-		{"missing key file", SshConfiguration{PrivateKeyPath: filepath.Join(dir, "no-such-file")}, false, true, "read private key file"},
-		{"invalid pem content", SshConfiguration{PrivateKey: "not a private key"}, false, true, "parse private key"},
+		{"plain PEM content", SshConfiguration{CertKeyFile: plainPEM}, false, false, ""},
+		{"plain PEM with redundant passphrase", SshConfiguration{CertKeyFile: plainPEM, Password: "ignored"}, false, false, ""},
+		{"plain PEM file", SshConfiguration{CertKeyFile: keyPath}, false, false, ""},
+		{"encrypted with correct passphrase", SshConfiguration{CertKeyFile: encryptedPEM, Password: passphrase}, false, false, ""},
+		{"encrypted with wrong passphrase", SshConfiguration{CertKeyFile: encryptedPEM, Password: "wrong-passphrase"}, false, true, ""},
+		{"encrypted without passphrase", SshConfiguration{CertKeyFile: encryptedPEM}, false, true, "password (used as passphrase)"},
+		{"missing key file", SshConfiguration{CertKeyFile: filepath.Join(dir, "no-such-file")}, false, true, "read private key file"},
+		{"invalid PEM content", SshConfiguration{CertKeyFile: "-----BEGIN RSA PRIVATE KEY-----\ninvalid"}, false, true, "parse private key"},
 	}
 
 	for _, tt := range tests {
@@ -106,11 +106,11 @@ func TestSshNodeInitPrivateKeyValidation(t *testing.T) {
 	t.Run("private key only passes validation", func(t *testing.T) {
 		node := &SshNode{}
 		err := node.Init(types.NewConfig(), types.Configuration{
-			"host":       "127.0.0.1",
-			"port":       22,
-			"username":   "root",
-			"privateKey": plainPEM,
-			"cmd":        "ls",
+			"host":        "127.0.0.1",
+			"port":        22,
+			"username":    "root",
+			"certKeyFile": plainPEM,
+			"cmd":         "ls",
 		})
 		assert.Nil(t, err)
 		assert.NotNil(t, node.signer)
@@ -123,29 +123,29 @@ func TestSshNodeInitPrivateKeyValidation(t *testing.T) {
 		assert.Nil(t, os.WriteFile(keyPath, []byte(plainPEM), 0600))
 		node := &SshNode{}
 		err := node.Init(types.NewConfig(), types.Configuration{
-			"host":           "127.0.0.1",
-			"port":           22,
-			"username":       "root",
-			"privateKeyPath": keyPath,
-			"cmd":            "ls",
+			"host":        "127.0.0.1",
+			"port":        22,
+			"username":    "root",
+			"certKeyFile": keyPath,
+			"cmd":         "ls",
 		})
 		assert.Nil(t, err)
 		assert.NotNil(t, node.signer)
 		node.Destroy()
 	})
 
-	t.Run("passphrase without private key", func(t *testing.T) {
+	t.Run("password and certKeyFile are mutually exclusive", func(t *testing.T) {
 		node := &SshNode{}
 		err := node.Init(types.NewConfig(), types.Configuration{
-			"host":                 "127.0.0.1",
-			"port":                 22,
-			"username":             "root",
-			"password":             "secret",
-			"privateKeyPassphrase": "pass",
-			"cmd":                  "ls",
+			"host":        "127.0.0.1",
+			"port":        22,
+			"username":    "root",
+			"password":    "secret",
+			"certKeyFile": plainPEM,
+			"cmd":         "ls",
 		})
 		assert.NotNil(t, err)
-		assert.Equal(t, SshConfigPassphraseNoKeyErr.Error(), err.Error())
+		assert.Equal(t, SshConfigPasswordKeyExclusiveErr.Error(), err.Error())
 	})
 
 	t.Run("neither password nor private key", func(t *testing.T) {
@@ -163,11 +163,11 @@ func TestSshNodeInitPrivateKeyValidation(t *testing.T) {
 	t.Run("invalid private key fails fast", func(t *testing.T) {
 		node := &SshNode{}
 		err := node.Init(types.NewConfig(), types.Configuration{
-			"host":       "127.0.0.1",
-			"port":       22,
-			"username":   "root",
-			"privateKey": "garbage",
-			"cmd":        "ls",
+			"host":        "127.0.0.1",
+			"port":        22,
+			"username":    "root",
+			"certKeyFile": "-----BEGIN RSA PRIVATE KEY-----\ngarbage",
+			"cmd":         "ls",
 		})
 		assert.NotNil(t, err)
 		assert.True(t, strings.Contains(err.Error(), "parse private key"))
@@ -177,7 +177,8 @@ func TestSshNodeInitPrivateKeyValidation(t *testing.T) {
 // TestSshNodeClientConfigAuth 覆盖 clientConfig 的认证方式组装。
 // TestSshNodeClientConfigAuth covers auth method assembly in clientConfig.
 func TestSshNodeClientConfigAuth(t *testing.T) {
-	plainPEM, _ := testKeyPair(t, "")
+	const passphrase = "test-passphrase"
+	plainPEM, encryptedPEM := testKeyPair(t, passphrase)
 
 	t.Run("password only", func(t *testing.T) {
 		node := &SshNode{Config: SshConfiguration{Username: "root", Password: "secret"}}
@@ -188,7 +189,7 @@ func TestSshNodeClientConfigAuth(t *testing.T) {
 	})
 
 	t.Run("private key only", func(t *testing.T) {
-		node := &SshNode{Config: SshConfiguration{Username: "root", PrivateKey: plainPEM}}
+		node := &SshNode{Config: SshConfiguration{Username: "root", CertKeyFile: plainPEM}}
 		signer, err := node.parseSigner()
 		assert.Nil(t, err)
 		node.signer = signer
@@ -199,16 +200,14 @@ func TestSshNodeClientConfigAuth(t *testing.T) {
 			"auth method should be publicKey type, got %s", reflect.TypeOf(cfg.Auth[0]))
 	})
 
-	t.Run("password and private key coexist", func(t *testing.T) {
-		node := &SshNode{Config: SshConfiguration{Username: "root", Password: "secret", PrivateKey: plainPEM}}
+	t.Run("private key with password (passphrase) uses public key only", func(t *testing.T) {
+		node := &SshNode{Config: SshConfiguration{Username: "root", Password: passphrase, CertKeyFile: encryptedPEM}}
 		signer, err := node.parseSigner()
 		assert.Nil(t, err)
 		node.signer = signer
 		cfg := node.clientConfig()
-		assert.Equal(t, 2, len(cfg.Auth))
-		assert.True(t, strings.Contains(reflect.TypeOf(cfg.Auth[0]).String(), "password"),
-			"first auth method should be password type, got %s", reflect.TypeOf(cfg.Auth[0]))
-		assert.True(t, strings.Contains(reflect.TypeOf(cfg.Auth[1]).String(), "publicKey"),
-			"second auth method should be publicKey type, got %s", reflect.TypeOf(cfg.Auth[1]))
+		assert.Equal(t, 1, len(cfg.Auth))
+		assert.True(t, strings.Contains(reflect.TypeOf(cfg.Auth[0]).String(), "publicKey"),
+			"auth method should be publicKey type, got %s", reflect.TypeOf(cfg.Auth[0]))
 	})
 }

--- a/components/external/ssh_node_key_test.go
+++ b/components/external/ssh_node_key_test.go
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2023 The RuleGo Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package external
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/rulego/rulego/api/types"
+	"github.com/rulego/rulego/test/assert"
+)
+
+// testKeyPair 生成测试用 RSA 私钥，返回明文 PEM 与加密 PEM（passphrase 为空时不生成加密版）。
+// testKeyPair generates a test RSA key pair and returns the plain PEM and the passphrase-encrypted PEM.
+func testKeyPair(t *testing.T, passphrase string) (plainPEM string, encryptedPEM string) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	assert.Nil(t, err)
+	der := x509.MarshalPKCS1PrivateKey(key)
+	plainPEM = string(pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: der}))
+	if passphrase != "" {
+		//nolint:staticcheck // EncryptPEMBlock is deprecated but still required to build encrypted PKCS#1 PEM in tests
+		block, err := x509.EncryptPEMBlock(rand.Reader, "RSA PRIVATE KEY", der, []byte(passphrase), x509.PEMCipherAES256)
+		assert.Nil(t, err)
+		encryptedPEM = string(pem.EncodeToMemory(block))
+	}
+	return plainPEM, encryptedPEM
+}
+
+// TestSshNodeParseSigner 覆盖私钥解析的各类场景。
+// TestSshNodeParseSigner covers private key parsing scenarios.
+func TestSshNodeParseSigner(t *testing.T) {
+	const passphrase = "test-passphrase"
+	plainPEM, encryptedPEM := testKeyPair(t, passphrase)
+
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "id_rsa")
+	assert.Nil(t, os.WriteFile(keyPath, []byte(plainPEM), 0600))
+
+	tests := []struct {
+		name        string
+		config      SshConfiguration
+		wantNil     bool
+		wantErr     bool
+		errContains string
+	}{
+		{"no private key", SshConfiguration{}, true, false, ""},
+		{"plain PEM content", SshConfiguration{PrivateKey: plainPEM}, false, false, ""},
+		{"plain PEM file", SshConfiguration{PrivateKeyPath: keyPath}, false, false, ""},
+		{"privateKey content takes precedence over path", SshConfiguration{PrivateKey: plainPEM, PrivateKeyPath: filepath.Join(dir, "missing")}, false, false, ""},
+		{"encrypted with correct passphrase", SshConfiguration{PrivateKey: encryptedPEM, PrivateKeyPassphrase: passphrase}, false, false, ""},
+		{"encrypted with wrong passphrase", SshConfiguration{PrivateKey: encryptedPEM, PrivateKeyPassphrase: "wrong-passphrase"}, false, true, ""},
+		{"encrypted without passphrase", SshConfiguration{PrivateKey: encryptedPEM}, false, true, "privateKeyPassphrase"},
+		{"missing key file", SshConfiguration{PrivateKeyPath: filepath.Join(dir, "no-such-file")}, false, true, "read private key file"},
+		{"invalid pem content", SshConfiguration{PrivateKey: "not a private key"}, false, true, "parse private key"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node := &SshNode{Config: tt.config}
+			signer, err := node.parseSigner()
+			if tt.wantErr {
+				assert.NotNil(t, err)
+				if tt.errContains != "" {
+					assert.True(t, strings.Contains(err.Error(), tt.errContains),
+						"error %q should contain %q", err.Error(), tt.errContains)
+				}
+				return
+			}
+			assert.Nil(t, err)
+			if tt.wantNil {
+				assert.Nil(t, signer)
+			} else {
+				assert.NotNil(t, signer)
+			}
+		})
+	}
+}
+
+// TestSshNodeInitPrivateKeyValidation 覆盖 Init 阶段私钥相关的校验。
+// TestSshNodeInitPrivateKeyValidation covers private key validation in Init.
+func TestSshNodeInitPrivateKeyValidation(t *testing.T) {
+	plainPEM, _ := testKeyPair(t, "")
+
+	t.Run("private key only passes validation", func(t *testing.T) {
+		node := &SshNode{}
+		err := node.Init(types.NewConfig(), types.Configuration{
+			"host":       "127.0.0.1",
+			"port":       22,
+			"username":   "root",
+			"privateKey": plainPEM,
+			"cmd":        "ls",
+		})
+		assert.Nil(t, err)
+		assert.NotNil(t, node.signer)
+		node.Destroy()
+	})
+
+	t.Run("private key file only passes validation", func(t *testing.T) {
+		dir := t.TempDir()
+		keyPath := filepath.Join(dir, "id_rsa")
+		assert.Nil(t, os.WriteFile(keyPath, []byte(plainPEM), 0600))
+		node := &SshNode{}
+		err := node.Init(types.NewConfig(), types.Configuration{
+			"host":           "127.0.0.1",
+			"port":           22,
+			"username":       "root",
+			"privateKeyPath": keyPath,
+			"cmd":            "ls",
+		})
+		assert.Nil(t, err)
+		assert.NotNil(t, node.signer)
+		node.Destroy()
+	})
+
+	t.Run("passphrase without private key", func(t *testing.T) {
+		node := &SshNode{}
+		err := node.Init(types.NewConfig(), types.Configuration{
+			"host":                 "127.0.0.1",
+			"port":                 22,
+			"username":             "root",
+			"password":             "secret",
+			"privateKeyPassphrase": "pass",
+			"cmd":                  "ls",
+		})
+		assert.NotNil(t, err)
+		assert.Equal(t, SshConfigPassphraseNoKeyErr.Error(), err.Error())
+	})
+
+	t.Run("neither password nor private key", func(t *testing.T) {
+		node := &SshNode{}
+		err := node.Init(types.NewConfig(), types.Configuration{
+			"host":     "127.0.0.1",
+			"port":     22,
+			"username": "root",
+			"cmd":      "ls",
+		})
+		assert.NotNil(t, err)
+		assert.Equal(t, SshConfigEmptyErr.Error(), err.Error())
+	})
+
+	t.Run("invalid private key fails fast", func(t *testing.T) {
+		node := &SshNode{}
+		err := node.Init(types.NewConfig(), types.Configuration{
+			"host":       "127.0.0.1",
+			"port":       22,
+			"username":   "root",
+			"privateKey": "garbage",
+			"cmd":        "ls",
+		})
+		assert.NotNil(t, err)
+		assert.True(t, strings.Contains(err.Error(), "parse private key"))
+	})
+}
+
+// TestSshNodeClientConfigAuth 覆盖 clientConfig 的认证方式组装。
+// TestSshNodeClientConfigAuth covers auth method assembly in clientConfig.
+func TestSshNodeClientConfigAuth(t *testing.T) {
+	plainPEM, _ := testKeyPair(t, "")
+
+	t.Run("password only", func(t *testing.T) {
+		node := &SshNode{Config: SshConfiguration{Username: "root", Password: "secret"}}
+		cfg := node.clientConfig()
+		assert.Equal(t, 1, len(cfg.Auth))
+		assert.True(t, strings.Contains(reflect.TypeOf(cfg.Auth[0]).String(), "password"),
+			"auth method should be password type, got %s", reflect.TypeOf(cfg.Auth[0]))
+	})
+
+	t.Run("private key only", func(t *testing.T) {
+		node := &SshNode{Config: SshConfiguration{Username: "root", PrivateKey: plainPEM}}
+		signer, err := node.parseSigner()
+		assert.Nil(t, err)
+		node.signer = signer
+		cfg := node.clientConfig()
+		assert.Equal(t, 1, len(cfg.Auth))
+		// 无私钥时不放空密码认证 - no empty password auth when password is empty
+		assert.True(t, strings.Contains(reflect.TypeOf(cfg.Auth[0]).String(), "publicKey"),
+			"auth method should be publicKey type, got %s", reflect.TypeOf(cfg.Auth[0]))
+	})
+
+	t.Run("password and private key coexist", func(t *testing.T) {
+		node := &SshNode{Config: SshConfiguration{Username: "root", Password: "secret", PrivateKey: plainPEM}}
+		signer, err := node.parseSigner()
+		assert.Nil(t, err)
+		node.signer = signer
+		cfg := node.clientConfig()
+		assert.Equal(t, 2, len(cfg.Auth))
+		assert.True(t, strings.Contains(reflect.TypeOf(cfg.Auth[0]).String(), "password"),
+			"first auth method should be password type, got %s", reflect.TypeOf(cfg.Auth[0]))
+		assert.True(t, strings.Contains(reflect.TypeOf(cfg.Auth[1]).String(), "publicKey"),
+			"second auth method should be publicKey type, got %s", reflect.TypeOf(cfg.Auth[1]))
+	})
+}

--- a/doc/components.json
+++ b/doc/components.json
@@ -555,6 +555,33 @@
         "fields": null
       },
       {
+        "name": "privateKey",
+        "type": "string",
+        "defaultValue": "",
+        "label": "",
+        "desc": "",
+        "validate": "",
+        "fields": null
+      },
+      {
+        "name": "privateKeyPath",
+        "type": "string",
+        "defaultValue": "",
+        "label": "",
+        "desc": "",
+        "validate": "",
+        "fields": null
+      },
+      {
+        "name": "privateKeyPassphrase",
+        "type": "string",
+        "defaultValue": "",
+        "label": "",
+        "desc": "",
+        "validate": "",
+        "fields": null
+      },
+      {
         "name": "cmd",
         "type": "string",
         "defaultValue": "",

--- a/doc/components.json
+++ b/doc/components.json
@@ -555,25 +555,7 @@
         "fields": null
       },
       {
-        "name": "privateKey",
-        "type": "string",
-        "defaultValue": "",
-        "label": "",
-        "desc": "",
-        "validate": "",
-        "fields": null
-      },
-      {
-        "name": "privateKeyPath",
-        "type": "string",
-        "defaultValue": "",
-        "label": "",
-        "desc": "",
-        "validate": "",
-        "fields": null
-      },
-      {
-        "name": "privateKeyPassphrase",
+        "name": "certKeyFile",
         "type": "string",
         "defaultValue": "",
         "label": "",

--- a/examples/ssh_node/ssh.go
+++ b/examples/ssh_node/ssh.go
@@ -42,12 +42,12 @@ func init() {
 // #!/bin/sh
 // echo "The first argument is $1"
 //
-// 认证方式二选一：
+// 认证方式二选一（互斥）：
 //   - 密码认证：配置 password
-//   - 公钥认证：配置 privateKey（私钥内容）或 privateKeyPath（私钥文件路径）；
-//     私钥加密时还需配置 privateKeyPassphrase，例如：
-//     "privateKeyPath": "/root/.ssh/id_rsa",
-//     "privateKeyPassphrase": "key-passphrase"
+//   - 公钥认证：配置 certKeyFile（私钥 PEM 内容或文件路径，自动识别）；
+//     私钥加密时 password 作为私钥口令，例如：
+//     "certKeyFile": "/root/.ssh/id_rsa",
+//     "password": "key-passphrase"
 func main() {
 
 	metaData := types.NewMetadata()

--- a/examples/ssh_node/ssh.go
+++ b/examples/ssh_node/ssh.go
@@ -41,6 +41,13 @@ func init() {
 // count.sh 内容
 // #!/bin/sh
 // echo "The first argument is $1"
+//
+// 认证方式二选一：
+//   - 密码认证：配置 password
+//   - 公钥认证：配置 privateKey（私钥内容）或 privateKeyPath（私钥文件路径）；
+//     私钥加密时还需配置 privateKeyPassphrase，例如：
+//     "privateKeyPath": "/root/.ssh/id_rsa",
+//     "privateKeyPassphrase": "key-passphrase"
 func main() {
 
 	metaData := types.NewMetadata()


### PR DESCRIPTION
### 背景 / Motivation

`SshNode` 目前仅支持密码认证（`ssh.Password`），无法使用密钥登录。本 PR 为 ssh 节点增加公钥认证能力：

- 私钥支持两种配置形式：PEM 内容（`privateKey`）或文件路径（`privateKeyPath`）
- 支持 passphrase 加密的私钥（`privateKeyPassphrase`）
- 密码与公钥认证可共存，由 SSH 服务器协商选择

### 改动点 / Changes

- **components/external/ssh_node.go**
  - `SshConfiguration` 新增三个可选字段：`privateKey`、`privateKeyPath`、`privateKeyPassphrase`
  - `Init` 校验调整为「密码或私钥至少配置其一」；新增 `SshConfigPassphraseNoKeyErr`（配置了口令但没有私钥时报错）
  - 新增 `parseSigner()`：在 `Init` 阶段解析并缓存签名器（fail-fast，密钥格式/口令错误提前暴露）；无口令时走 `ssh.ParsePrivateKey`，命中 `*ssh.PassphraseMissingError` 时给出「请配置 privateKeyPassphrase」的可读提示
  - 新增 `clientConfig()` 并让 `initClient` 复用：密码与公钥认证共存于 `Auth` 数组，密码为空时不再附加空密码认证
  - 文件头部注释补充公钥认证配置示例
- **components/external/ssh_node_key_test.go**（新增）
  - `TestSshNodeParseSigner`：明文/加密私钥、内容/路径、口令错误/缺失、文件不存在、非法 PEM 等 9 个场景
  - `TestSshNodeInitPrivateKeyValidation`：纯私钥通过校验、口令无私钥报错、密码私钥全空报错、非法私钥 fail-fast
  - `TestSshNodeClientConfigAuth`：仅密码/仅私钥/两者共存三种认证组装
- **doc/components.json**：ssh 节点 fields 补充三个新字段（可视化配置界面可用）
- **examples/ssh_node/ssh.go**：补充公钥认证与 passphrase 的配置说明

### 配置示例 / Configuration

```json
{
  "type": "ssh",
  "configuration": {
    "host": "192.168.1.100",
    "port": 22,
    "username": "root",
    "privateKeyPath": "/root/.ssh/id_rsa",
    "privateKeyPassphrase": "key-passphrase",
    "cmd": "ls -la /tmp"
  }
}
```

privateKey（PEM 内容）与 privateKeyPath（文件路径）二选一，内容优先；privateKeyPassphrase 仅当私钥被口令加密时必填，与登录密码 password 相互独立。

兼容性 / Compatibility

- 旧 DSL 配置（纯密码）行为零变化：新增字段均为可选、带 omitempty，缺省走原有密码认证路径
- Init 校验仅放宽（密码必填 → 密码或私钥至少其一），不影响任何既有合法配置
- 新增 SshConfigPassphraseNoKeyErr 错误变量，既有错误变量不变